### PR TITLE
Add Raycast implementation

### DIFF
--- a/src/Input.ts
+++ b/src/Input.ts
@@ -4,6 +4,7 @@ import { CellType } from "./Map";
 import { Camera } from "./Camera";
 import { GetMode } from "./main";
 import { gl } from "./engine/Core";
+import { RayCast } from "./engine/Raycast";
 
 let editorCamera: Camera;
 
@@ -20,16 +21,16 @@ let alpha = 0, // angle between X-axis and camera (X,Z) position - (0,0)
 /* --------------------------------------------------- */
 
 export function Init() {
-	document.addEventListener("keydown", HandleInputFromKeyboad);
-	document.addEventListener("keyup", HandleInputReleaseFromKeyboard);
-	gl.canvas.addEventListener("pointerdown", HandleInputFromPointer);
+	document.addEventListener("keydown", HandleInputKeyDown);
+	document.addEventListener("keyup", HandleInputKeyUp);
+	gl.canvas.addEventListener("pointerdown", HandleInputPointerDown);
 	gl.canvas.addEventListener("pointerup", () => {
 		isPointerActive = false;
 		isPointerSecondaryActive = false;
 	});
-	gl.canvas.addEventListener("pointermove", HandleDragInputFromPointer);
+	gl.canvas.addEventListener("pointermove", HandleInputPointerDrag);
 	gl.canvas.addEventListener("contextmenu", HandleRightClick);
-	gl.canvas.addEventListener("wheel", HandleScroll);
+	gl.canvas.addEventListener("wheel", HandleInputScroll);
 
 	// Get editor camera
 	editorCamera = Camera.Get("editor");
@@ -40,7 +41,7 @@ export var moveDir = [0, 0, 0];
 // Afaik Javascript doesn't let us read keyboard state directly, so we'll have
 // to listen for both a key release and a key press
 
-function HandleInputFromKeyboad(ev: KeyboardEvent) {
+function HandleInputKeyDown(ev: KeyboardEvent) {
 	if (GetMode() === "EDITOR") {
 		let t: number[];
 
@@ -148,7 +149,7 @@ function HandleInputFromKeyboad(ev: KeyboardEvent) {
 	}
 }
 
-function HandleInputReleaseFromKeyboard(ev: KeyboardEvent) {
+function HandleInputKeyUp(ev: KeyboardEvent) {
 	if (GetMode() === "GAME") {
 		switch (ev.key) {
 			// Movement
@@ -178,7 +179,7 @@ function HandleInputReleaseFromKeyboard(ev: KeyboardEvent) {
 	}
 }
 
-function HandleDragInputFromPointer(ev: PointerEvent) {
+function HandleInputPointerDrag(ev: PointerEvent) {
 	ev.preventDefault();
 	if (isPointerActive) {
 		// Do stuff with mouse (requires raycasts)
@@ -199,7 +200,7 @@ function HandleRightClick(ev: MouseEvent) {
 	return false;
 }
 
-function HandleInputFromPointer(ev: PointerEvent) {
+function HandleInputPointerDown(ev: PointerEvent) {
 	ev.preventDefault();
 	// Handle mouse down events
 	mouseDownPos = {
@@ -209,9 +210,12 @@ function HandleInputFromPointer(ev: PointerEvent) {
 		beta: beta,
 	};
 	isPointerActive = true;
+
+	// Raycast
+	RayCast(gl, ev.clientX, ev.clientY, editorCamera);
 }
 
-function HandleScroll(ev: any) {
+function HandleInputScroll(ev: any) {
 	ev.preventDefault();
 	let scrollDir = -Math.sign(ev.wheelDeltaY);
 

--- a/src/engine/Core.ts
+++ b/src/engine/Core.ts
@@ -7,8 +7,8 @@ import { WebGLProgramInfo } from "./Shaders";
 
 export const ROOT_NODE: Node<State> = new Node("root");
 export let gl: WebGL2RenderingContext;
-let projectionMatrix = utils.identityMatrix();
-let cameraMatrix = utils.identityMatrix();
+export let projectionMatrix = utils.identityMatrix();
+export let cameraMatrix = utils.identityMatrix();
 
 const N_LIGHTS = 16;
 const lights = new Array<Light>(N_LIGHTS);

--- a/src/engine/Raycast.ts
+++ b/src/engine/Raycast.ts
@@ -1,0 +1,55 @@
+import { DrawLine, LineColor } from "./debug/Lines";
+import { utils } from "../utils/utils";
+import { cameraMatrix, projectionMatrix } from "./Core";
+import { Camera } from "../Camera";
+
+export function RayCast(
+	gl: WebGL2RenderingContext,
+	x: number,
+	y: number,
+	camera: Camera
+) {
+	const normX = (2 * x) / gl.canvas.width - 1;
+	const normY = 1 - (2 * y) / gl.canvas.height;
+
+	//We need to go through the transformation pipeline in the inverse order so we invert the matrices
+	const invProj = utils.invertMatrix(projectionMatrix);
+	const invView = cameraMatrix;
+
+	//Find the point (un)projected on the near plane, from clip space coords to eye coords
+	//z = -1 makes it so the point is on the near plane
+	//w = 1 is for the homogeneous coordinates in clip space
+	const pointEyeCoords = utils.multiplyMatrixVector(invProj, [
+		normX,
+		normY,
+		-1,
+		1,
+	]);
+
+	//This finds the direction of the ray in eye space
+	//Formally, to calculate the direction you would do dir = point - eyePos but since we are in eye space eyePos = [0,0,0]
+	//w = 0 is because this is not a point anymore but is considered as a direction
+	var rayEyeCoords = [
+		pointEyeCoords[0],
+		pointEyeCoords[1],
+		pointEyeCoords[2],
+		0,
+	];
+
+	//We find the direction expressed in world coordinates by multipling with the inverse of the view matrix
+	const rayDir = utils.multiplyMatrixVector(invView, rayEyeCoords);
+	const normalisedRayDir = utils.normalize(rayDir);
+	//The ray starts from the camera in world coordinates
+
+	var rayStartPoint = camera.GetPosition();
+
+	// Draw the ray we're casting
+	DrawLine(
+		rayStartPoint,
+		utils.addVectors(
+			rayStartPoint,
+			utils.multiplyVectorScalar(rayDir, 100)
+		),
+		LineColor.PURPLE
+	);
+}


### PR DESCRIPTION
We're using the direction-based method, instead of the one that finds two points on the near and far plane of the frustum

Other minor changes:
- Refactor input methods names

How to test:
You should rotate the camera to see the actual ray.
The ray is drawn from the camera origin to the point (well, direction in this implementation) you're clicking in 3D world space.