### PR TITLE
Add (fake) shadows

### DIFF
--- a/src/engine/SceneGraph.ts
+++ b/src/engine/SceneGraph.ts
@@ -4,6 +4,7 @@ import * as Engine from "./Core";
 import { Light } from "./Lights";
 import { WebGLProgramInfo } from "./Shaders";
 import { gl } from "./Core";
+import { Shadow } from "./Shadows";
 
 // A function that receives the state of the Node and performs actions on it
 export type Action<T extends State> = (
@@ -169,6 +170,7 @@ export class RenderNode<T extends IRenderableState> extends Node<T> {
 		);
 
 		Engine.BindAllLightUniforms(this.state.programInfo);
+		Engine.BindAllShadowUniforms(this.state.programInfo);
 
 		// Render Texture
 		if (this.state.texture) {
@@ -227,5 +229,30 @@ export class LightNode<T extends State> extends Node<T> {
 		// );
 
 		Engine.AddLight(this.light);
+	}
+}
+
+export class ShadowNode<T extends State> extends Node<T> {
+	shadow: Shadow = new Shadow();
+
+	constructor(name: string, shadow: Shadow, localMatrix?: number[]) {
+		super(name, localMatrix);
+		this.shadow = shadow;
+	}
+
+	override Update(deltaTime: number, worldMatrix?: number[]) {
+		super.Update(deltaTime, worldMatrix);
+		this.shadow.pos = utils.ComputePosition(
+			this.state.worldMatrix,
+			[0, 0, 0]
+		);
+		const down = [0, -1, 0]; // default direction
+		const p2 = utils.ComputePosition(this.state.worldMatrix, down);
+
+		this.shadow.dir = utils.subtractVectors(p2, this.shadow.pos);
+
+		this.shadow.dir = utils.normalize(this.shadow.dir);
+
+		Engine.AddShadow(this.shadow);
 	}
 }

--- a/src/engine/Shaders.ts
+++ b/src/engine/Shaders.ts
@@ -27,6 +27,7 @@ export interface WebGLProgramInfo {
 		normalMap?: WebGLUniformLocation;
 		specularMap?: WebGLUniformLocation;
 		ambientOcclusion?: WebGLUniformLocation;
+		// lights
 		lightType: WebGLUniformLocation;
 		lightPos: WebGLUniformLocation;
 		lightDir: WebGLUniformLocation;
@@ -35,6 +36,15 @@ export interface WebGLProgramInfo {
 		lightDecay: WebGLUniformLocation;
 		lightTarget: WebGLUniformLocation;
 		lightColor: WebGLUniformLocation;
+		// shadows
+		shadowPos: WebGLUniformLocation;
+		shadowDir: WebGLUniformLocation;
+		shadowConeOut: WebGLUniformLocation;
+		shadowConeIn: WebGLUniformLocation;
+		shadowDecay: WebGLUniformLocation;
+		shadowTarget: WebGLUniformLocation;
+		shadowColor: WebGLUniformLocation;
+
 		ambientLight: WebGLUniformLocation;
 		eyePos: WebGLUniformLocation;
 	};
@@ -107,6 +117,13 @@ export function getShader(features: number) {
 			lightDecay: gl.getUniformLocation(program, "LDecay"),
 			lightTarget: gl.getUniformLocation(program, "LTarget"),
 			lightColor: gl.getUniformLocation(program, "LColor"),
+			shadowPos: gl.getUniformLocation(program, "SdwPos"),
+			shadowDir: gl.getUniformLocation(program, "SdwDir"),
+			shadowConeOut: gl.getUniformLocation(program, "SdwConeOut"),
+			shadowConeIn: gl.getUniformLocation(program, "SdwConeIn"),
+			shadowDecay: gl.getUniformLocation(program, "SdwDecay"),
+			shadowTarget: gl.getUniformLocation(program, "SdwTarget"),
+			shadowColor: gl.getUniformLocation(program, "SdwColor"),
 			ambientLight: gl.getUniformLocation(program, "ambientLight"),
 			eyePos: gl.getUniformLocation(program, "eyePos"),
 		},

--- a/src/engine/Shadows.ts
+++ b/src/engine/Shadows.ts
@@ -1,0 +1,25 @@
+export class Shadow {
+	pos: number[] = [0, 0, 0];
+	dir: number[] = [0, 0, 0];
+	coneOut: number = 0;
+	coneIn: number = 0;
+	decay: number = 0;
+	target: number = 1;
+	color: number[] = [0, 0, 0, 1];
+
+	static Make(
+		color: number[],
+		coneOut: number,
+		coneIn: number,
+		targetDistance?: number,
+		decay?: number
+	) {
+		const l = new Shadow();
+		l.color = color;
+		l.coneOut = coneOut;
+		l.coneIn = coneIn;
+		if (targetDistance) l.target = targetDistance;
+		if (decay) l.decay = decay;
+		return l;
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,14 @@ import { utils } from "./utils/utils";
 import * as Engine from "./engine/Core";
 import * as toad from "./models/Toad";
 import { Light } from "./engine/Lights";
-import { LightNode } from "./engine/SceneGraph";
+import { LightNode, ShadowNode } from "./engine/SceneGraph";
 import * as DebugLine from "./engine/debug/Lines";
 import * as UI from "./UI";
 
 import { Camera } from "./Camera";
 import * as Input from "./Input";
 import * as Map from "./Map";
+import { Shadow } from "./engine/Shadows";
 
 type Mode = "EDITOR" | "GAME";
 

--- a/src/models/Toad.ts
+++ b/src/models/Toad.ts
@@ -1,6 +1,11 @@
 import * as Engine from "../engine/Core";
 import { MakeTexture, MakeVAO, TextureType } from "../engine/Models";
-import { IRenderableState, RenderNode, State } from "../engine/SceneGraph";
+import {
+	IRenderableState,
+	RenderNode,
+	ShadowNode,
+	State,
+} from "../engine/SceneGraph";
 import { getShader, Features, WebGLProgramInfo } from "../engine/Shaders";
 import { gl } from "../engine/Core";
 import { utils } from "../utils/utils";
@@ -24,6 +29,7 @@ import {
 	PhysicsNode,
 	PhysicsState,
 } from "../engine/Physics";
+import { Shadow } from "../engine/Shadows";
 
 // Define common structure for state of these nodes
 interface ToadState extends PhysicsState {
@@ -129,11 +135,24 @@ export function Spawn() {
 		)
 	);
 
+	var shadowBelow = new ShadowNode(
+		"shadow-toad",
+		Shadow.Make(
+			[1, 1, 1, 1.0], // color
+			40, // coneOut, deg°
+			0.5, // coneIn, %
+			2, // targetDistance
+			1 // decay)
+		),
+		utils.MakeTranslateMatrix(0, 1, 0)
+	);
+
 	toadNode.AddAction(JumpAction);
 	toadNode.AddAction(MovementAction);
 
 	// Set relationships between nodes
 	headLight.SetParent(toadNode);
+	shadowBelow.SetParent(toadNode);
 	toadNode.SetParent(Engine.ROOT_NODE);
 
 	return toadNode;

--- a/src/shaders/fs.glsl
+++ b/src/shaders/fs.glsl
@@ -100,8 +100,12 @@ vec3 compShadowDir(vec3 LPos, vec3 LDir) {
 }
 
 vec4 compShadowColor(vec4 shadowColor, float SdwTarget, float SdwDecay, vec3 SdwPos, vec3 SdwDir, float SdwConeOut, float SdwConeIn) {
-	float SdwCosOut = cos(radians(SdwConeOut / 2.0));
-	float SdwCosIn = cos(radians(SdwConeOut * SdwConeIn / 2.0));
+	// Calc the distance between the ShadowSource and the "ground"
+	// (since fake shadows are always vertical)
+	// Then divide the angle in radians by it to shrink the shadow angle
+	float invHeight = 1.0 / max(SdwPos.y - fsPosition.y, 1.0);
+	float SdwCosOut = cos(radians(SdwConeOut / 2.0) * invHeight);
+	float SdwCosIn = cos(radians(SdwConeOut * SdwConeIn / 2.0) * invHeight);
 
 	// -> Spot
 	vec3 shadowDir = normalize(SdwPos - fsPosition);

--- a/src/shaders/fs.glsl
+++ b/src/shaders/fs.glsl
@@ -47,6 +47,15 @@ uniform float LDecay[N_LIGHTS];
 uniform float LTarget[N_LIGHTS];
 uniform vec4 LColor[N_LIGHTS];
 
+#define N_SHADOWS 16
+uniform vec3 SdwPos[N_SHADOWS];
+uniform vec3 SdwDir[N_SHADOWS];
+uniform float SdwConeOut[N_SHADOWS];
+uniform float SdwConeIn[N_SHADOWS];
+uniform float SdwDecay[N_SHADOWS];
+uniform float SdwTarget[N_SHADOWS];
+uniform vec4 SdwColor[N_SHADOWS];
+
 uniform vec3 ambientLight;
 
 #define SPEC_SHINE 100.0
@@ -84,6 +93,21 @@ vec4 compLightColor(vec4 lightColor, float LTarget, float LDecay, vec3 LPos, vec
 	return directLightCol * lightType.x +
 		   pointLightCol * lightType.y +
 		   spotLightCol * lightType.z;
+}
+
+vec3 compShadowDir(vec3 LPos, vec3 LDir) {
+	return normalize(LPos - fsPosition);
+}
+
+vec4 compShadowColor(vec4 shadowColor, float SdwTarget, float SdwDecay, vec3 SdwPos, vec3 SdwDir, float SdwConeOut, float SdwConeIn) {
+	float SdwCosOut = cos(radians(SdwConeOut / 2.0));
+	float SdwCosIn = cos(radians(SdwConeOut * SdwConeIn / 2.0));
+
+	// -> Spot
+	vec3 shadowDir = normalize(SdwPos - fsPosition);
+	float CosAngle = dot(shadowDir, SdwDir);
+	return shadowColor * pow(SdwTarget / length(SdwPos - fsPosition), SdwDecay) *
+						clamp((CosAngle - SdwCosOut) / (SdwCosIn - SdwCosOut), 0.0, 1.0);
 }
 
 vec4 compSpecular(vec3 lightDir, vec4 lightCol, vec3 normalVec, vec3 eyedirVec) {
@@ -136,6 +160,14 @@ void main() {
 		lightsSpecular += compSpecular(lightDir, lightCol, normalVec, eyedirVec);
 	}
 
+	//shadows
+	vec4 shadowsDiffuse;
+	for (int i = 0; i < N_SHADOWS; i++) {
+		vec3 shadowDir = compShadowDir(SdwPos[i], SdwDir[i]);
+		vec4 shadowCol = compShadowColor(SdwColor[i], SdwTarget[i], SdwDecay[i], SdwPos[i], SdwDir[i], SdwConeOut[i], SdwConeIn[i]);
+		shadowsDiffuse += max(0.0, dot(shadowDir, normalVec)) * shadowCol;
+	}
+
 	vec4 diffColor = vec4(mDiffColor, 1.0);
 	vec4 emitColor = vec4(mEmitColor, 1.0);
 	vec4 ambColor = vec4(mAmbColor, 1.0);
@@ -155,7 +187,7 @@ void main() {
 	diffColor *= texture(ambientOcclusion, uvCoord);
 #endif
 
-	vec4 lambertColor = diffColor * lightsDiffuse;
+	vec4 lambertColor = diffColor * lightsDiffuse * (1.0 - shadowsDiffuse);
 	vec4 blinnColor = specColor * lightsSpecular;
 	vec4 ambientColor = vec4(ambientLight, 1.0) * ambColor;
 	outColor = clamp(lambertColor + blinnColor + emitColor + ambientColor, 0.0, 1.0);


### PR DESCRIPTION
They are not really shadows, they are just inverse light sources!

It's a subset reimplementation of the current LightNode: only spotlight (or spot-_shadows_) are used.

Plus the angle (ConeOut) of the shadow cone is shrinked when the shadow source moves upwards